### PR TITLE
Set options from a config file + SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ and loads data from such dump files back into Redis.
 - Can load TTL OR original expiration time for expiring keys;
 - Dumps are human readable
 - Dumps are line-aligned (can be streamed)
+- SSL support
+- Can load options from a INI configuration file
 - Can be used as a module in a larger program or as a standalone utility
 
 ## Python 2/3 Compatability
@@ -23,11 +25,16 @@ Use python3 for restoring dumps taken using python3
 
 ## Basic usage
 
-```
-python3 pyredis-dump.py -h
-python3 pyredis-dump.py dblist
-python3 pyredis-dump.py dump -o outfile.py3redis
-python3 pyredis-dump.py restore -i outfile.py3redis
-```
+```bash
+# From the command-line
+$ python3 pyredis-dump.py -h
+$ python3 pyredis-dump.py dblist
+$ python3 pyredis-dump.py dump -o outfile.py3redis
+$ python3 pyredis-dump.py restore -i outfile.py3redis
+$ python3 pyredis-dump.py dblist --ssl -H my.host -P SECRET
 
-
+# Using a configuration file
+$ python3 pyredis-dump.py dblist -c config.ini
+$ python3 pyredis-dump.py dump -c config.ini
+$ python3 pyredis-dump.py restore -c config.ini
+```

--- a/config.ini.example
+++ b/config.ini.example
@@ -1,0 +1,8 @@
+[myconfig]
+host = 127.0.0.1
+port = 6379
+password = SUPERSECRET
+ssl = True
+db = 3
+outfile = path/to/file
+infile = path/to/file

--- a/pyredis-dump.py
+++ b/pyredis-dump.py
@@ -1,163 +1,201 @@
 #! /usr/bin/env python
 
-import time
-import configargparse
 import ast
+import configargparse
 import pathlib
 import re
+import time
 from redis import StrictRedis as Redis
 
+
 class RedisDump(Redis):
-  def __init__(self, *a, **kw):
-    Redis.__init__(self, *a, **kw)
-    version = [int(part) for part in self.info()['redis_version'].split('.')]
-    self._have_pttl = version >= [2, 6]
-    self._types = set(['string', 'list', 'set', 'zset', 'hash'])
+    def __init__(self, *a, **kw):
+        Redis.__init__(self, *a, **kw)
+        version = [int(part)
+                   for part in self.info()['redis_version'].split('.')]
+        self._have_pttl = version >= [2, 6]
+        self._types = set(['string', 'list', 'set', 'zset', 'hash'])
 
-  def get_one(self, key):
-    type = self.type(key)
-    p = self.pipeline()
-    p.watch(key)
-    p.multi()
-    p.type(key)
-    if self._have_pttl:
-      p.pttl(key)
-    else:
-      p.ttl(key)
-    if type==b'string': p.get(key)
-    elif type==b'list': p.lrange(key, 0, -1)
-    elif type==b'set':  p.smembers(key)
-    elif type==b'zset': p.zrange(key, 0, -1, False, True)
-    elif type==b'hash': p.hgetall(key)
-    else: raise TypeError('Unknown type=%r' % type)
-    type2, ttl, value = p.execute()
-    if self._have_pttl and ttl>0:
-      ttl = ttl / 1000.0
-    if type!=type2: raise TypeError("Type changed")
-    if ttl>0:
-      expire_at = time.time() + ttl
-    else: expire_at=-1
-    return type, key, ttl, expire_at, value
+    def get_one(self, key):
+        type = self.type(key)
+        p = self.pipeline()
+        p.watch(key)
+        p.multi()
+        p.type(key)
+        if self._have_pttl:
+            p.pttl(key)
+        else:
+            p.ttl(key)
+        if type == b'string':
+            p.get(key)
+        elif type == b'list':
+            p.lrange(key, 0, -1)
+        elif type == b'set':
+            p.smembers(key)
+        elif type == b'zset':
+            p.zrange(key, 0, -1, False, True)
+        elif type == b'hash':
+            p.hgetall(key)
+        else:
+            raise TypeError('Unknown type=%r' % type)
+        type2, ttl, value = p.execute()
+        if self._have_pttl and ttl > 0:
+            ttl = ttl / 1000.0
+        if type != type2:
+            raise TypeError("Type changed")
+        if ttl > 0:
+            expire_at = time.time() + ttl
+        else:
+            expire_at = -1
+        return type, key, ttl, expire_at, value
 
-  def pattern_iter(self, pattern="*"):
-    for key in self.keys(pattern):
-      yield self.get_one(key)
-  
-  def dump(self, outfile, pattern="*"):
-    for type, key, ttl, expire_at, value in self.pattern_iter(pattern):
-      line=repr((type, key, ttl, expire_at, value,))
-      outfile.write(line+"\n")
+    def pattern_iter(self, pattern="*"):
+        for key in self.keys(pattern):
+            yield self.get_one(key)
 
-  def set_one(self, p, use_ttl, key_type, key, ttl, expire_at, value):
-    p.delete(key)
-    if key_type==b'string':
-      p.set(key, value)
-    elif key_type==b'list':
-      for element in value:
-        p.rpush(key, element)
-    elif key_type==b'set':
-      for element in value:
-        p.sadd(key, element)
-    elif key_type==b'zset':
-      for element, score in value:
-        p.zadd(key, score, element)
-    elif key_type==b'hash':
-      p.hmset(key, value)
-    else: raise TypeError('Unknown type=%r' % type)
-    if ttl<=0: return
-    if use_ttl:
-      if type(ttl) is int:
-        p.expire(key, ttl)
-      else: p.pexpire(key, int(ttl * 1000))
-    else:
-      if type(expire_at) is int:
-        p.expireat(key, expire_at)
-      else: p.pexpireat(key, int(expire_at * 1000))
+    def dump(self, outfile, pattern="*"):
+        for type, key, ttl, expire_at, value in self.pattern_iter(pattern):
+            line = repr((type, key, ttl, expire_at, value,))
+            outfile.write(line+"\n")
 
-  def restore(self, infile, use_ttl=False, bulk_size=1000):
-    p = self.pipeline(transaction=False)
-    dirty=False
-    for i, line in enumerate(infile):
-      line = line.strip()
-      if not line: continue
-      a=ast.literal_eval(line)
-      if len(a)!=5: raise ValueError("expecting type, key, ttl, expire_at, value got %r" % a)
-      type, key, ttl, expire_at, value = a
-      self.set_one(p, use_ttl, type, key, ttl, expire_at, value)
-      dirty=True
-      if i % bulk_size == 0:
-        dirty=False
-        p.execute()
+    def set_one(self, p, use_ttl, key_type, key, ttl, expire_at, value):
+        p.delete(key)
+        if key_type == b'string':
+            p.set(key, value)
+        elif key_type == b'list':
+            for element in value:
+                p.rpush(key, element)
+        elif key_type == b'set':
+            for element in value:
+                p.sadd(key, element)
+        elif key_type == b'zset':
+            for element, score in value:
+                p.zadd(key, score, element)
+        elif key_type == b'hash':
+            p.hmset(key, value)
+        else:
+            raise TypeError('Unknown type=%r' % type)
+        if ttl <= 0:
+            return
+        if use_ttl:
+            if type(ttl) is int:
+                p.expire(key, ttl)
+            else:
+                p.pexpire(key, int(ttl * 1000))
+        else:
+            if type(expire_at) is int:
+                p.expireat(key, expire_at)
+            else:
+                p.pexpireat(key, int(expire_at * 1000))
+
+    def restore(self, infile, use_ttl=False, bulk_size=1000):
         p = self.pipeline(transaction=False)
-    if dirty: p.execute()
+        dirty = False
+        for i, line in enumerate(infile):
+            line = line.strip()
+            if not line:
+                continue
+            a = ast.literal_eval(line)
+            if len(a) != 5:
+                raise ValueError(
+                    "expecting type, key, ttl, expire_at, value got %r" % a)
+            type, key, ttl, expire_at, value = a
+            self.set_one(p, use_ttl, type, key, ttl, expire_at, value)
+            dirty = True
+            if i % bulk_size == 0:
+                dirty = False
+                p.execute()
+                p = self.pipeline(transaction=False)
+        if dirty:
+            p.execute()
+
 
 def dump(filename, pattern="*", **kw):
-  r=RedisDump(**kw)
-  p = pathlib.Path(filename)
-  p.parents[0].mkdir(parents=True, exist_ok=True)
-  with open(filename, "w+") as outfile:
-    r.dump(outfile, pattern)
+    r = RedisDump(**kw)
+    p = pathlib.Path(filename)
+    p.parents[0].mkdir(parents=True, exist_ok=True)
+    with open(filename, "w+") as outfile:
+        r.dump(outfile, pattern)
+
 
 def restore(filename, use_ttl=True, bulk_size=1000, **kw):
-  r=RedisDump(**kw)
-  with open(filename, "r+") as infile:
-    r.restore(infile)
+    r = RedisDump(**kw)
+    with open(filename, "r+") as infile:
+        r.restore(infile)
 
-db_re=re.compile(r'db\d+')
+
+db_re = re.compile(r'db\d+')
+
 
 def dblist(**kw):
-  r=Redis(**kw)
-  for i in sorted(filter( lambda k: db_re.match(k), r.info().keys() )):
-    print(i.replace("db", ""))
+    r = Redis(**kw)
+    for i in sorted(filter(lambda k: db_re.match(k), r.info().keys())):
+        print(i.replace("db", ""))
+
 
 def options2kw(options):
-  kw={'db':options['db']}
-  if options['socket']: kw['unix_socket_path']=options['socket']
-  else:
-    kw['host']=options['host']
-    kw['port']=options['port']
-  if options['password']: kw['password']=options['password']
-  if options['ssl']: kw['ssl']=options['ssl']
-  return kw
-  
+    kw = {'db': options['db']}
+    if options['socket']:
+        kw['unix_socket_path'] = options['socket']
+    else:
+        kw['host'] = options['host']
+        kw['port'] = options['port']
+    if options['password']:
+        kw['password'] = options['password']
+    if options['ssl']:
+        kw['ssl'] = options['ssl']
+    return kw
+
 
 def main():
-  host = 'localhost'
-  db = 0
-  parser = configargparse.ArgParser()
-  parser.add_argument('mode', nargs='+', help='[dump|restore|dblist]')
-  parser.add_argument('-c', '--config-file', required=False, is_config_file=True, help='config file path')
-  parser.add_argument('-H', '--host', help='connect to HOST (default localhost)', default='localhost')
-  parser.add_argument('-P', '--port', help='connect to PORT (default 6379)', default=6379, type=int)
-  parser.add_argument('-s', '--socket', help='connect to SOCKET')
-  parser.add_argument('-d', '--db', help='database', default=0, type=int)
-  parser.add_argument('-w', '--password', help='connect with PASSWORD')
-  parser.add_argument('-p', '--pattern', help='pattern', default='*')
-  parser.add_argument('-o', '--outfile', help='write to OUTFILE')
-  parser.add_argument('-i', '--infile', help='read from INFILE')
-  parser.add_argument('-t', action='store_true', dest='use_ttl', help='use ttl when in restore mode')
-  parser.add_argument('-b', '--bulk', help='restore bulk size', default=1000, type=int)
-  parser.add_argument('-x', '--ssl', action='store_true', dest="ssl", help='connect with SSL (default false)', default=False)
-  args = parser.parse_args()
-  options = vars(args)
+    host = 'localhost'
+    db = 0
+    parser = configargparse.ArgParser()
+    parser.add_argument('mode', nargs='+', help='[dump|restore|dblist]')
+    parser.add_argument('-c', '--config-file', required=False,
+                        is_config_file=True, help='config file path')
+    parser.add_argument(
+        '-H', '--host', help='connect to HOST (default localhost)', default='localhost')
+    parser.add_argument(
+        '-P', '--port', help='connect to PORT (default 6379)', default=6379, type=int)
+    parser.add_argument('-s', '--socket', help='connect to SOCKET')
+    parser.add_argument('-d', '--db', help='database', default=0, type=int)
+    parser.add_argument('-w', '--password', help='connect with PASSWORD')
+    parser.add_argument('-p', '--pattern', help='pattern', default='*')
+    parser.add_argument('-o', '--outfile', help='write to OUTFILE')
+    parser.add_argument('-i', '--infile', help='read from INFILE')
+    parser.add_argument('-t', action='store_true',
+                        dest='use_ttl', help='use ttl when in restore mode')
+    parser.add_argument(
+        '-b', '--bulk', help='restore bulk size', default=1000, type=int)
+    parser.add_argument('-x', '--ssl', action='store_true', dest="ssl",
+                        help='connect with SSL (default false)', default=False)
+    args = parser.parse_args()
+    options = vars(args)
 
-  mode = args.mode[0]
-  kw = options2kw(options)
-  if mode=='dump':
-    if not options['outfile']: parser.error("missing outfile, use '-o'")
-    print("dumping to %r" % options['outfile'])
-    print("connecting to '%s:%d/%d'" % (options['host'], options['port'], options['db']))
-    dump(options['outfile'], options['pattern'], **kw)
-  elif mode=='restore':
-    if not options['infile']: parser.error("missing infile, use '-i'")
-    print("restore from %r" % options['infile'])
-    print("connecting to '%s:%d/%d'" % (options['host'], options['port'], options['db']))
-    restore(options['infile'], use_ttl=options['use_ttl'], bulk_size=options['bulk'], **kw)
-  elif mode=='dblist':
-    dblist(**kw)
-  else:
-    parser.print_help()
-    parser.error("unknown mode %r" % mode)
+    mode = args.mode[0]
+    kw = options2kw(options)
+    if mode == 'dump':
+        if not options['outfile']:
+            parser.error("missing outfile, use '-o'")
+        print("dumping to %r" % options['outfile'])
+        print("connecting to '%s:%d/%d'" %
+              (options['host'], options['port'], options['db']))
+        dump(options['outfile'], options['pattern'], **kw)
+    elif mode == 'restore':
+        if not options['infile']:
+            parser.error("missing infile, use '-i'")
+        print("restore from %r" % options['infile'])
+        print("connecting to '%s:%d/%d'" %
+              (options['host'], options['port'], options['db']))
+        restore(options['infile'], use_ttl=options['use_ttl'],
+                bulk_size=options['bulk'], **kw)
+    elif mode == 'dblist':
+        dblist(**kw)
+    else:
+        parser.print_help()
+        parser.error("unknown mode %r" % mode)
 
-if __name__=='__main__':
-  main()
+
+if __name__ == '__main__':
+    main()

--- a/pyredis-dump.py
+++ b/pyredis-dump.py
@@ -122,7 +122,7 @@ def main():
   db = 0
   parser = optparse.OptionParser(usage="usage: %prog [options] dump|restore|dblist")
   parser.add_option('-H', '--host', help='connect to HOST (default localhost)', default='localhost')
-  parser.add_option('-P', '--port', help='connect to PORT (default 6379)', default=6379, type="int")
+  parser.add_argument('-c', '--config-file', required=False, is_config_file=True, help='config file path')
   parser.add_option('-s', '--socket', help='connect to SOCKET')
   parser.add_option('-d', '--db', help='database', default=0, type="int")
   parser.add_option('-w', '--password', help='connect with PASSWORD')

--- a/pyredis-dump.py
+++ b/pyredis-dump.py
@@ -3,6 +3,7 @@
 import time
 import optparse
 import ast
+import pathlib
 import re
 from redis import StrictRedis as Redis
 
@@ -92,6 +93,8 @@ class RedisDump(Redis):
 
 def dump(filename, pattern="*", **kw):
   r=RedisDump(**kw)
+  p = pathlib.Path(filename)
+  p.parents[0].mkdir(parents=True, exist_ok=True)
   with open(filename, "w+") as outfile:
     r.dump(outfile, pattern)
 

--- a/pyredis-dump.py
+++ b/pyredis-dump.py
@@ -114,9 +114,7 @@ def options2kw(options):
   kw={'db':options.db}
   if options.socket: kw['unix_socket_path']=options.socket
   else:
-    kw['host']=options.host
-    kw['port']=options.port
-  if options.password: kw['password']=options.password
+  if options['ssl']: kw['ssl']=options['ssl']
   return kw
 
 def main():
@@ -135,7 +133,7 @@ def main():
   parser.add_option("-t", action="store_true", dest="use_ttl", help="use ttl when in restore mode")
   parser.add_option('-b', '--bulk', help='restore bulk size', default=1000, type="int")
   options, args = parser.parse_args()
-  if len(args)!=1:
+  parser.add_argument('-x', '--ssl', action='store_true', dest="ssl", help='connect with SSL (default false)', default=False)
     parser.print_help()
     parser.error("wrong number of arguments")
     


### PR DESCRIPTION
This PR to introduce the following changes: 

- [x] replace the deprecated `optparse` module by `configargparse` 
- [x] add ssl support with `-x` or `--ssl` (set to True)
- [x] options can be set from a `.ini` configuration file
- [x] will create the directories if `OUTFILE` path doesn't exist

How to use:

```bash

# Connect to a redis instance with SSL from the command-line
$ ./pyredis-dump.py dblist -x -H redis.host -P 16379 -w MYSECRET
0
1

# Connect to a redis instance using a .ini file (SSL included)
$ cat config.ini
[myconfig]
host = redis.host
port = 16379
password =MYSECRET
ssl = True

$ ./pyredis-dump.py dblist -c config.ini
0
1

# Connect to a redis instance using a .ini file (SSL in command-line)
$ ./pyredis-dump.py dblist -c config.ini -x
```