### PR TITLE
Added ability to dump to stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@
 ### INI ###
 *.ini
 
+### Dumps ###
+*.dump
+*.outfile
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,3 +32,5 @@ COPY --chown=$USER_NAME:$GROUP_NAME . .
 USER $USER_NAME
 
 ENV PATH="$APP_ROOT/venv/bin:$PATH"
+
+ENTRYPOINT ["python", "pyredis-dump.py"]

--- a/pyredis-dump.py
+++ b/pyredis-dump.py
@@ -151,7 +151,7 @@ def main():
     host = 'localhost'
     db = 0
     parser = configargparse.ArgParser()
-    parser.add_argument('mode', nargs='+', help='[dump|restore|dblist]')
+    parser.add_argument('mode', nargs='+', help='[dblist|dump|restore]')
     parser.add_argument('-c', '--config-file', required=False,
                         is_config_file=True, help='config file path')
     parser.add_argument(

--- a/pyredis-dump.py
+++ b/pyredis-dump.py
@@ -72,7 +72,7 @@ class RedisDump(Redis):
             for element, score in value:
                 p.zadd(key, score, element)
         elif key_type == b'hash':
-            p.hmset(key, value)
+            p.hset(key, mapping=value)
         else:
             raise TypeError('Unknown type=%r' % type)
         if ttl <= 0:


### PR DESCRIPTION
This PR will give the user the ability to dump to stdout. That way, a user can choose to:

print a dump:
```bash
# Using python
$ python3 pyredis-dump.py dump
(b'string', b'somestring', somedata)

# Using docker
$ docker run --rm -it \
  -v $(pwd)/config.ini:/app/config.ini --name some-dump pyredis-dump dump -c config.ini
(b'string', b'somestring', somedata)
```
store it in a host file:
```bash
# Using python
$ python3 pyredis-dump.py dump -o file.dump
connecting to 'localhost:6379/0'
dumping to 'myfile.dump'

# Using docker
$ docker run --rm -it \
  -v $(pwd)/config.ini:/app/config.ini --name some-dump pyredis-dump dump -c config.ini > myfile.dump
```

or in a docker volume:
```bash
$ docker volume create myvol
$ docker run --rm -it \
  -v $(pwd)/config.ini:/app/config.ini \
  -v myvol:/data --name some-dump pyredis-dump dump -c config.ini -o /data/myfile.dump
connecting to 'my.remote.host:6379/0'
dumping to '/data/myfile.dump'
```

